### PR TITLE
Bugfix: #85 홈/어웨이 여부에 따라 팀 vs 팀 표기 순서 통일

### DIFF
--- a/CheerLot/CheerLot/Data/RepositoryImpl/Setting/UserSettingsRepositoryImpl.swift
+++ b/CheerLot/CheerLot/Data/RepositoryImpl/Setting/UserSettingsRepositoryImpl.swift
@@ -39,4 +39,16 @@ final class UserSettingsRepositoryImpl: UserSettingsRepository {
   func setLineupUpdatedToday(_ value: Bool, for teamId: TeamID) {
     sharedDefaults.set(value, forKey: UserDefaultsKey.lineupUpdatedToday(for: teamId))
   }
+
+  func getLineupIsHome(for teamId: TeamID) -> Bool? {
+    sharedDefaults.object(forKey: "lineupIsHome.\(teamId.value)") as? Bool
+  }
+
+  func setLineupIsHome(_ value: Bool?, for teamId: TeamID) {
+    if let value {
+      sharedDefaults.set(value, forKey: "lineupIsHome.\(teamId.value)")
+    } else {
+      sharedDefaults.removeObject(forKey: "lineupIsHome.\(teamId.value)")
+    }
+  }
 }

--- a/CheerLot/CheerLot/Domain/Entity/Team/LineupData.swift
+++ b/CheerLot/CheerLot/Domain/Entity/Team/LineupData.swift
@@ -11,6 +11,7 @@ struct LineupData {
   let gameInfo: TeamGameInfo
   let lineupPlayers: [PlayerInfo]
   let opponentTeamId: TeamID?
+  let isHome: Bool?
   // lineupUpdatedToday=false일 때, teamData.gameInfo (최근 완료된 경기 정보). showLineup=true 상태에서 사용.
   let recentGameInfo: TeamGameInfo?
 }

--- a/CheerLot/CheerLot/Domain/Entity/Team/LineupData.swift
+++ b/CheerLot/CheerLot/Domain/Entity/Team/LineupData.swift
@@ -10,7 +10,6 @@ import Foundation
 struct LineupData {
   let gameInfo: TeamGameInfo
   let lineupPlayers: [PlayerInfo]
-  let opponentTeamId: TeamID?
   let isHome: Bool?
   // lineupUpdatedToday=false일 때, teamData.gameInfo (최근 완료된 경기 정보). showLineup=true 상태에서 사용.
   let recentGameInfo: TeamGameInfo?

--- a/CheerLot/CheerLot/Domain/Entity/Team/LineupData.swift
+++ b/CheerLot/CheerLot/Domain/Entity/Team/LineupData.swift
@@ -14,4 +14,5 @@ struct LineupData {
   let isHome: Bool?
   // lineupUpdatedToday=false일 때, teamData.gameInfo (최근 완료된 경기 정보). showLineup=true 상태에서 사용.
   let recentGameInfo: TeamGameInfo?
+  let recentGameIsHome: Bool?
 }

--- a/CheerLot/CheerLot/Domain/Repository/Interface/Setting/UserSettingsRepository.swift
+++ b/CheerLot/CheerLot/Domain/Repository/Interface/Setting/UserSettingsRepository.swift
@@ -23,4 +23,10 @@ protocol UserSettingsRepository {
 
   /// 오늘 해당 팀의 라인업 업데이트 여부를 저장한다
   func setLineupUpdatedToday(_ value: Bool, for teamId: TeamID)
+
+  /// 가장 최근 라인업 업데이트 시점의 홈/어웨이 여부를 반환한다
+  func getLineupIsHome(for teamId: TeamID) -> Bool?
+
+  /// 가장 최근 라인업 업데이트 시점의 홈/어웨이 여부를 저장한다
+  func setLineupIsHome(_ value: Bool?, for teamId: TeamID)
 }

--- a/CheerLot/CheerLot/Domain/UseCaseImpl/Lineup/LineupManagementUseCaseImpl.swift
+++ b/CheerLot/CheerLot/Domain/UseCaseImpl/Lineup/LineupManagementUseCaseImpl.swift
@@ -206,6 +206,7 @@ final class LineupManagementUseCaseImpl: LineupManagementUseCase {
       lineupUpdatedToday ? teamData.gameInfo.opponent : todaySchedule?.opponentTeamId
     let starterPitcherName: String? =
       lineupUpdatedToday ? teamData.gameInfo.starterPitcherName : todaySchedule?.starterPitcherName
+    let isHome: Bool? = gameScheduleRepository.fetchGameSchedule(for: teamId)?.recentGames.first?.isHome
 
     // Entity단의 경기 상태 매칭
     let finalStatus: GameStatus =
@@ -226,6 +227,7 @@ final class LineupManagementUseCaseImpl: LineupManagementUseCase {
       gameInfo: resolvedGameInfo,
       lineupPlayers: lineupPlayers,
       opponentTeamId: opponentTeamId,
+      isHome: isHome,
       recentGameInfo: recentGameInfo
     )
   }

--- a/CheerLot/CheerLot/Domain/UseCaseImpl/Lineup/LineupManagementUseCaseImpl.swift
+++ b/CheerLot/CheerLot/Domain/UseCaseImpl/Lineup/LineupManagementUseCaseImpl.swift
@@ -206,7 +206,8 @@ final class LineupManagementUseCaseImpl: LineupManagementUseCase {
       lineupUpdatedToday ? teamData.gameInfo.opponent : todaySchedule?.opponentTeamId
     let starterPitcherName: String? =
       lineupUpdatedToday ? teamData.gameInfo.starterPitcherName : todaySchedule?.starterPitcherName
-    let isHome: Bool? = gameScheduleRepository.fetchGameSchedule(for: teamId)?.recentGames.first?.isHome
+    let isHome: Bool? = gameScheduleRepository.fetchGameSchedule(for: teamId)?.recentGames.first?
+      .isHome
 
     // Entity단의 경기 상태 매칭
     let finalStatus: GameStatus =

--- a/CheerLot/CheerLot/Domain/UseCaseImpl/Lineup/LineupManagementUseCaseImpl.swift
+++ b/CheerLot/CheerLot/Domain/UseCaseImpl/Lineup/LineupManagementUseCaseImpl.swift
@@ -194,9 +194,16 @@ final class LineupManagementUseCaseImpl: LineupManagementUseCase {
     // 오늘 라인업 업데이트 여부
     let lineupUpdatedToday = userSettingsRepository.getLineupUpdatedToday(for: teamId)
 
+    // 라인업이 오늘 업데이트됐을 때 스케줄의 isHome을 저장 (추후 recentGameInfo용으로 활용)
+    if lineupUpdatedToday {
+      let currentIsHome = gameScheduleRepository.fetchGameSchedule(for: teamId)?.recentGames.first?.isHome
+      userSettingsRepository.setLineupIsHome(currentIsHome, for: teamId)
+    }
+
     // lineupUpdatedToday=false일 때 teamData.gameInfo는 최근 완료 경기 정보 (최근 투수, 상대팀, 날짜)
     // showLineup=true 시 ViewModel에서 사용하도록 전달
     let recentGameInfo: TeamGameInfo? = lineupUpdatedToday ? nil : teamData.gameInfo
+    let recentGameIsHome: Bool? = lineupUpdatedToday ? nil : userSettingsRepository.getLineupIsHome(for: teamId)
 
     // 기본 화면 표시용: lineupUpdatedToday=true면 teamData 직접 사용, false면 스케줄 API 첫번째 경기 사용
     let todaySchedule =
@@ -229,7 +236,8 @@ final class LineupManagementUseCaseImpl: LineupManagementUseCase {
       lineupPlayers: lineupPlayers,
       opponentTeamId: opponentTeamId,
       isHome: isHome,
-      recentGameInfo: recentGameInfo
+      recentGameInfo: recentGameInfo,
+      recentGameIsHome: recentGameIsHome
     )
   }
 

--- a/CheerLot/CheerLot/Domain/UseCaseImpl/Lineup/LineupManagementUseCaseImpl.swift
+++ b/CheerLot/CheerLot/Domain/UseCaseImpl/Lineup/LineupManagementUseCaseImpl.swift
@@ -194,10 +194,12 @@ final class LineupManagementUseCaseImpl: LineupManagementUseCase {
     // 오늘 라인업 업데이트 여부
     let lineupUpdatedToday = userSettingsRepository.getLineupUpdatedToday(for: teamId)
 
+    /// 최근 3경기 스케줄 중 첫번째 경기 (오늘)
+    let firstRecentGame = gameScheduleRepository.fetchGameSchedule(for: teamId)?.recentGames.first
+
     // 라인업이 오늘 업데이트됐을 때 스케줄의 isHome을 저장 (추후 recentGameInfo용으로 활용)
     if lineupUpdatedToday {
-      let currentIsHome = gameScheduleRepository.fetchGameSchedule(for: teamId)?.recentGames.first?.isHome
-      userSettingsRepository.setLineupIsHome(currentIsHome, for: teamId)
+      userSettingsRepository.setLineupIsHome(firstRecentGame?.isHome, for: teamId)
     }
 
     // lineupUpdatedToday=false일 때 teamData.gameInfo는 최근 완료 경기 정보 (최근 투수, 상대팀, 날짜)
@@ -206,15 +208,12 @@ final class LineupManagementUseCaseImpl: LineupManagementUseCase {
     let recentGameIsHome: Bool? = lineupUpdatedToday ? nil : userSettingsRepository.getLineupIsHome(for: teamId)
 
     // 기본 화면 표시용: lineupUpdatedToday=true면 teamData 직접 사용, false면 스케줄 API 첫번째 경기 사용
-    let todaySchedule =
-      lineupUpdatedToday
-      ? nil : gameScheduleRepository.fetchGameSchedule(for: teamId)?.recentGames.first
+    let todaySchedule = lineupUpdatedToday ? nil : firstRecentGame
     let opponentTeamId: TeamID? =
       lineupUpdatedToday ? teamData.gameInfo.opponent : todaySchedule?.opponentTeamId
     let starterPitcherName: String? =
       lineupUpdatedToday ? teamData.gameInfo.starterPitcherName : todaySchedule?.starterPitcherName
-    let isHome: Bool? = gameScheduleRepository.fetchGameSchedule(for: teamId)?.recentGames.first?
-      .isHome
+    let isHome: Bool? = firstRecentGame?.isHome
 
     // Entity단의 경기 상태 매칭
     let finalStatus: GameStatus =
@@ -234,7 +233,6 @@ final class LineupManagementUseCaseImpl: LineupManagementUseCase {
     return LineupData(
       gameInfo: resolvedGameInfo,
       lineupPlayers: lineupPlayers,
-      opponentTeamId: opponentTeamId,
       isHome: isHome,
       recentGameInfo: recentGameInfo,
       recentGameIsHome: recentGameIsHome

--- a/CheerLot/CheerLot/Presentation/Lineup/ValueObject/LineupGameInfoVO.swift
+++ b/CheerLot/CheerLot/Presentation/Lineup/ValueObject/LineupGameInfoVO.swift
@@ -14,11 +14,13 @@ struct LineupGameInfoVO: Equatable {
   let opponent: String?
   let starterPitcher: String?
   let status: GameStatus
+  let isHome: Bool?
 
   init(
     teamInfo: TeamInfo,
     opponentTeamInfo: TeamInfo?,
-    gameInfo: TeamGameInfo
+    gameInfo: TeamGameInfo,
+    isHome: Bool? = nil
   ) {
     self.teamName = teamInfo.shortName
     self.teamEnglishName = teamInfo.englishFullName
@@ -26,6 +28,7 @@ struct LineupGameInfoVO: Equatable {
     self.opponent = opponentTeamInfo?.shortName
     self.starterPitcher = gameInfo.starterPitcherName
     self.status = gameInfo.status
+    self.isHome = isHome
   }
 
   var todayGameInfoText: String {
@@ -40,7 +43,7 @@ struct LineupGameInfoVO: Equatable {
 
   var gameTeamsText: String {
     if let opponent = opponent {
-      "\(teamName) vs \(opponent)"
+      isHome == true ? "\(opponent) vs \(teamName)" : "\(teamName) vs \(opponent)"
     } else {
       "경기없음"
     }

--- a/CheerLot/CheerLot/Presentation/Lineup/ViewModel/LineupPlaybackViewModel.swift
+++ b/CheerLot/CheerLot/Presentation/Lineup/ViewModel/LineupPlaybackViewModel.swift
@@ -121,11 +121,12 @@ final class LineupPlaybackViewModel {
     // recentGameInfo가 없으면 gameInfo (-> lineupUpdatedToday=true)
     let displayGameInfo = data.recentGameInfo ?? data.gameInfo
     let opponentTeamInfo = displayGameInfo.opponent.flatMap { teamInfoUseCase.getTeamInfo($0) }
+    let displayIsHome = data.recentGameInfo != nil ? data.recentGameIsHome : data.isHome
     let lineupGameInfoVO = LineupGameInfoVO(
       teamInfo: teamInfo,
       opponentTeamInfo: opponentTeamInfo,
       gameInfo: displayGameInfo,
-      isHome: data.isHome
+      isHome: displayIsHome
     )
 
     gameDate = lineupGameInfoVO.gameDateText

--- a/CheerLot/CheerLot/Presentation/Lineup/ViewModel/LineupPlaybackViewModel.swift
+++ b/CheerLot/CheerLot/Presentation/Lineup/ViewModel/LineupPlaybackViewModel.swift
@@ -124,7 +124,8 @@ final class LineupPlaybackViewModel {
     let lineupGameInfoVO = LineupGameInfoVO(
       teamInfo: teamInfo,
       opponentTeamInfo: opponentTeamInfo,
-      gameInfo: displayGameInfo
+      gameInfo: displayGameInfo,
+      isHome: data.isHome
     )
 
     gameDate = lineupGameInfoVO.gameDateText

--- a/CheerLot/CheerLot/Presentation/Lineup/ViewModel/LineupViewModel.swift
+++ b/CheerLot/CheerLot/Presentation/Lineup/ViewModel/LineupViewModel.swift
@@ -168,7 +168,7 @@ final class LineupViewModel {
     guard let teamInfo = teamInfoUseCase.getTeamInfo(TeamID(teamId)) else { return }
 
     // 상대팀 정보 조회
-    let opponentTeamInfo = data.opponentTeamId.flatMap {
+    let opponentTeamInfo = data.gameInfo.opponent.flatMap {
       teamInfoUseCase.getTeamInfo($0)
     }
 

--- a/CheerLot/CheerLot/Presentation/Lineup/ViewModel/LineupViewModel.swift
+++ b/CheerLot/CheerLot/Presentation/Lineup/ViewModel/LineupViewModel.swift
@@ -176,7 +176,8 @@ final class LineupViewModel {
     gameInfo = LineupGameInfoVO(
       teamInfo: teamInfo,
       opponentTeamInfo: opponentTeamInfo,
-      gameInfo: data.gameInfo
+      gameInfo: data.gameInfo,
+      isHome: data.isHome
     )
 
     // 최근 완료 경기 VO (showLineup=true 시 사용)

--- a/CheerLot/CheerLot/Presentation/Lineup/ViewModel/LineupViewModel.swift
+++ b/CheerLot/CheerLot/Presentation/Lineup/ViewModel/LineupViewModel.swift
@@ -186,7 +186,8 @@ final class LineupViewModel {
       recentGameInfoVO = LineupGameInfoVO(
         teamInfo: teamInfo,
         opponentTeamInfo: recentOpponentInfo,
-        gameInfo: recentInfo
+        gameInfo: recentInfo,
+        isHome: data.recentGameIsHome
       )
     } else {
       recentGameInfoVO = nil

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeGameInfo/View/HomeGameInfoMediumWidgetView.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeGameInfo/View/HomeGameInfoMediumWidgetView.swift
@@ -65,16 +65,15 @@ extension HomeGameInfoMediumWidgetView {
   }
 
   private var gameInfoContentsView: some View {
-    HStack(spacing: 37) {
-      teamInfoView(
-        asset: teamAsset,
-        team: entry.teamLongName,
-        pitcher: entry.gameSchedule.first?.starterPitcherName
-      )
+    let isHome = entry.gameSchedule.first?.isHome == true
+    let myTeamView = teamInfoView(
+      asset: teamAsset,
+      team: entry.teamLongName,
+      pitcher: entry.gameSchedule.first?.starterPitcherName
+    )
 
-      dateInfoView
-
-      if let opponentAsset = opponentTeamAsset,
+    return HStack(spacing: 37) {
+      if isHome, let opponentAsset = opponentTeamAsset,
         let opponentLongName = entry.gameSchedule.first?.opponentLongName
       {
         teamInfoView(
@@ -82,6 +81,20 @@ extension HomeGameInfoMediumWidgetView {
           team: opponentLongName,
           pitcher: entry.gameSchedule.first?.opponentStarterPitcherName
         )
+        dateInfoView
+        myTeamView
+      } else {
+        myTeamView
+        dateInfoView
+        if let opponentAsset = opponentTeamAsset,
+          let opponentLongName = entry.gameSchedule.first?.opponentLongName
+        {
+          teamInfoView(
+            asset: opponentAsset,
+            team: opponentLongName,
+            pitcher: entry.gameSchedule.first?.opponentStarterPitcherName
+          )
+        }
       }
     }
   }

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeGameInfo/View/HomeGameInfoSmallWidgetView.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeGameInfo/View/HomeGameInfoSmallWidgetView.swift
@@ -22,10 +22,12 @@ struct HomeGameInfoSmallWidgetView: View {
     if entry.gameStatus == .teamEmpty {
       TeamEmptyView(isSmallSize: true)
     } else {
+      let isHome = entry.gameSchedule.first?.isHome == true
+      let opponent = entry.gameSchedule.first?.opponentShortName ?? ""
       let title: String =
         switch entry.gameStatus {
         case .playingToday:
-          "\(entry.teamShortName) vs \(entry.gameSchedule.first?.opponentShortName ?? "")"
+          "\(isHome ? opponent : entry.teamShortName) vs \(isHome ? entry.teamShortName : opponent)"
         case .offDay: "경기 없음"
         case .seasonEnded: "시즌 종료"
         case .teamEmpty: ""

--- a/CheerLot/WidgetCheerLot/Presentation/LockScreen/Widget/LockScreenInlineWidget.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/LockScreen/Widget/LockScreenInlineWidget.swift
@@ -19,7 +19,8 @@ struct LockScreenInlineWidgetView: View {
     case .playingToday:
       let isHome = entry.gameSchedule.first?.isHome == true
       let opponent = entry.gameSchedule.first?.opponentShortName ?? ""
-      return "\(isHome ? opponent : entry.teamShortName) VS \(isHome ? entry.teamShortName : opponent)"
+      return
+        "\(isHome ? opponent : entry.teamShortName) VS \(isHome ? entry.teamShortName : opponent)"
     case .offDay: return "경기 없음"
     case .seasonEnded: return "시즌 종료"
     }

--- a/CheerLot/WidgetCheerLot/Presentation/LockScreen/Widget/LockScreenInlineWidget.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/LockScreen/Widget/LockScreenInlineWidget.swift
@@ -17,8 +17,9 @@ struct LockScreenInlineWidgetView: View {
     switch entry.gameStatus {
     case .teamEmpty: return "팀 정보 없음"
     case .playingToday:
+      let isHome = entry.gameSchedule.first?.isHome == true
       let opponent = entry.gameSchedule.first?.opponentShortName ?? ""
-      return "\(entry.teamShortName) VS \(opponent)"
+      return "\(isHome ? opponent : entry.teamShortName) VS \(isHome ? entry.teamShortName : opponent)"
     case .offDay: return "경기 없음"
     case .seasonEnded: return "시즌 종료"
     }

--- a/CheerLot/WidgetCheerLot/Presentation/LockScreen/Widget/LockScreenRectangularWidget.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/LockScreen/Widget/LockScreenRectangularWidget.swift
@@ -19,7 +19,8 @@ struct LockScreenRectangularWidgetView: View {
     case .playingToday:
       let isHome = entry.gameSchedule.first?.isHome == true
       let opponent = entry.gameSchedule.first?.opponentShortName ?? ""
-      return "\(isHome ? opponent : entry.teamShortName) vs \(isHome ? entry.teamShortName : opponent)"
+      return
+        "\(isHome ? opponent : entry.teamShortName) vs \(isHome ? entry.teamShortName : opponent)"
     case .offDay: return "경기 없음"
     case .seasonEnded: return "시즌 종료"
     }

--- a/CheerLot/WidgetCheerLot/Presentation/LockScreen/Widget/LockScreenRectangularWidget.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/LockScreen/Widget/LockScreenRectangularWidget.swift
@@ -17,8 +17,9 @@ struct LockScreenRectangularWidgetView: View {
     switch entry.gameStatus {
     case .teamEmpty: return "팀 정보 없음"
     case .playingToday:
+      let isHome = entry.gameSchedule.first?.isHome == true
       let opponent = entry.gameSchedule.first?.opponentShortName ?? ""
-      return "\(entry.teamShortName) vs \(opponent)"
+      return "\(isHome ? opponent : entry.teamShortName) vs \(isHome ? entry.teamShortName : opponent)"
     case .offDay: return "경기 없음"
     case .seasonEnded: return "시즌 종료"
     }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #85 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 홈/어웨이 여부에 따라 팀 vs 팀 표기 순서 통일 (Widget, iOS)

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->


<img width="300"  alt="스크린샷, 2026-04-21 14 58 23" src="https://github.com/user-attachments/assets/ee435272-7b4f-442b-a336-34875498f4ab" />
<img width="300"  alt="스크린샷, 2026-04-21 14 58 05" src="https://github.com/user-attachments/assets/e757c617-c999-4e8a-ab91-d0e182e88ca0" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 17, iOS 26 환경에서 정상 동작
- [x] Swift-format 실행 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 라인업에 경기의 홈/어웨이 정보를 저장하고 불러오는 설정 기능을 추가했습니다.
  * 홈/어웨이 정보가 라인업 및 경기 정보 표시에 일관되게 반영됩니다.

* **Bug Fixes**
  * 위젯(홈/잠금 화면)과 라인업 화면에서 홈/어웨이에 따라 팀 이름의 순서와 경기 표시가 올바르게 표시되도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->