### PR TITLE
Bugfix: #87 iPad/MacOS 라인업 카드 레이아웃, 위젯 tint 및 경기없을 때 버그 수정

### DIFF
--- a/CheerLot/CheerLot/Core/DesignSystem/Font+.swift
+++ b/CheerLot/CheerLot/Core/DesignSystem/Font+.swift
@@ -236,6 +236,15 @@ extension TypeStyle {
     letterSpacing: 0
   )
 
+  /// SemiBold 18pt_lineupNameCompact
+  public static let SB5_lineupNameCompact = TypeStyle(
+    font: Font.Pretendard.semibold.swiftUIFont(size: 18),
+    uiFont: Font.Pretendard.semibold.uiFont(size: 18),
+    size: 18,
+    lineHeight: 1.0,
+    letterSpacing: 0
+  )
+
   /// SemiBold 18pt
   public static let SB6 = TypeStyle(
     font: Font.Pretendard.semibold.swiftUIFont(size: 18),
@@ -286,6 +295,15 @@ extension TypeStyle {
     font: Font.Pretendard.medium.swiftUIFont(size: 28),
     uiFont: Font.Pretendard.medium.uiFont(size: 28),
     size: 28,
+    lineHeight: 1.3,
+    letterSpacing: 0
+  )
+
+  /// Medium 24pt_lineupCompact
+  public static let M0_lineupCompact = TypeStyle(
+    font: Font.Pretendard.medium.swiftUIFont(size: 24),
+    uiFont: Font.Pretendard.medium.uiFont(size: 24),
+    size: 24,
     lineHeight: 1.3,
     letterSpacing: 0
   )
@@ -349,6 +367,15 @@ extension TypeStyle {
     font: Font.Pretendard.medium.swiftUIFont(size: 12),
     uiFont: Font.Pretendard.medium.uiFont(size: 12),
     size: 12,
+    lineHeight: 1.0,
+    letterSpacing: -0.05
+  )
+
+  /// Medium 10pt_positionCompact
+  public static let M5_positionCompact = TypeStyle(
+    font: Font.Pretendard.medium.swiftUIFont(size: 10),
+    uiFont: Font.Pretendard.medium.uiFont(size: 10),
+    size: 10,
     lineHeight: 1.0,
     letterSpacing: -0.05
   )

--- a/CheerLot/CheerLot/Domain/UseCaseImpl/Lineup/LineupManagementUseCaseImpl.swift
+++ b/CheerLot/CheerLot/Domain/UseCaseImpl/Lineup/LineupManagementUseCaseImpl.swift
@@ -205,7 +205,8 @@ final class LineupManagementUseCaseImpl: LineupManagementUseCase {
     // lineupUpdatedToday=false일 때 teamData.gameInfo는 최근 완료 경기 정보 (최근 투수, 상대팀, 날짜)
     // showLineup=true 시 ViewModel에서 사용하도록 전달
     let recentGameInfo: TeamGameInfo? = lineupUpdatedToday ? nil : teamData.gameInfo
-    let recentGameIsHome: Bool? = lineupUpdatedToday ? nil : userSettingsRepository.getLineupIsHome(for: teamId)
+    let recentGameIsHome: Bool? =
+      lineupUpdatedToday ? nil : userSettingsRepository.getLineupIsHome(for: teamId)
 
     // 기본 화면 표시용: lineupUpdatedToday=true면 teamData 직접 사용, false면 스케줄 API 첫번째 경기 사용
     let todaySchedule = lineupUpdatedToday ? nil : firstRecentGame

--- a/CheerLot/CheerLot/Presentation/Lineup/Component/LineupMemberCell.swift
+++ b/CheerLot/CheerLot/Presentation/Lineup/Component/LineupMemberCell.swift
@@ -11,12 +11,13 @@ import SwiftUI
 struct LineupMemberCell: View {
   let player: LineupPlayerVO
   let asset: LineupAssetVO
+  let isCompact: Bool
 
   var body: some View {
     HStack(spacing: 12) {
       if let battingOrder = player.battingOrder {
         Text("\(battingOrder)")
-          .font(.M0)
+          .font(isCompact ? .M0_lineupCompact : .M0)
           .foregroundStyle(asset.battingOrderTextColor)
       }
 
@@ -27,9 +28,10 @@ struct LineupMemberCell: View {
       Image(systemName: "play.fill")
         .resizable()
         .scaledToFit()
-        .frame(width: 12)
+        .frame(width: isCompact ? 10 : 12)
         .foregroundStyle(player.hasSong ? .grayWhite : asset.playDisableColor)
     }
+    .frame(maxHeight: .infinity)
   }
 }
 
@@ -37,11 +39,11 @@ extension LineupMemberCell {
   private var textContents: some View {
     HStack(alignment: .bottom, spacing: 8) {
       Text(player.name)
-        .font(.SB5_lineupName)
+        .font(isCompact ? .SB5_lineupNameCompact : .SB5_lineupName)
         .foregroundStyle(.grayWhite)
 
       Text(player.batThrow.isEmpty ? player.position : "\(player.position), \(player.batThrow)")
-        .font(.M5_position)
+        .font(isCompact ? .M5_positionCompact : .M5_position)
         .foregroundStyle(asset.positionTextColor)
     }
   }

--- a/CheerLot/CheerLot/Presentation/Lineup/View/LineupView.swift
+++ b/CheerLot/CheerLot/Presentation/Lineup/View/LineupView.swift
@@ -19,12 +19,25 @@ struct LineupView: View {
   // MARK: - Layout Constants
   private let teamNameHeight: CGFloat = 44.5
   private let gameInfoHeight: CGFloat = 26.5
-  private let cardTopPadding: CGFloat = 20
-  private let cardBottomPadding: CGFloat = 10
-  private let cardSpacing: CGFloat = 4
   private let separatorHeight: CGFloat = 1
   private let safeAreaVerticalPadding: CGFloat = 10
   private let safeAreaHorizontalPadding: CGFloat = 20
+
+  private func isCompact(cardHeight: CGFloat) -> Bool {
+    cardHeight < 550
+  }
+
+  private func cardTopPadding(cardHeight: CGFloat) -> CGFloat {
+    isCompact(cardHeight: cardHeight) ? 12 : 20
+  }
+
+  private func cardBottomPadding(cardHeight: CGFloat) -> CGFloat {
+    isCompact(cardHeight: cardHeight) ? 6 : 10
+  }
+
+  private func cardSpacing(cardHeight: CGFloat) -> CGFloat {
+    isCompact(cardHeight: cardHeight) ? 2 : 4
+  }
 
   var body: some View {
     GeometryReader { geo in
@@ -73,8 +86,9 @@ struct LineupView: View {
   private func listHeight(cardHeight: CGFloat) -> CGFloat {
     max(
       0,
-      cardHeight - teamNameHeight - gameInfoHeight - cardTopPadding - cardBottomPadding
-        - cardSpacing * 3)
+      cardHeight - teamNameHeight - gameInfoHeight - cardTopPadding(cardHeight: cardHeight)
+        - cardBottomPadding(cardHeight: cardHeight) - cardSpacing(cardHeight: cardHeight) * 3
+    )
   }
 
   private func cellHeight(cardHeight: CGFloat) -> CGFloat {
@@ -115,11 +129,11 @@ extension LineupView {
     -> some View
   {
     ZStack {
-      VStack(spacing: cardSpacing) {
+      VStack(spacing: cardSpacing(cardHeight: cardHeight)) {
 
         if let gameInfo = viewModel.gameInfo {
-          teamName(asset: asset, gameInfo: gameInfo)
-            .padding(.bottom, cardSpacing)
+          teamName(asset: asset, gameInfo: gameInfo, cardHeight: cardHeight)
+            .padding(.bottom, cardSpacing(cardHeight: cardHeight))
           gameInfoView(asset: asset, gameInfo: gameInfo)
         }
 
@@ -127,9 +141,9 @@ extension LineupView {
           lineupList(asset: asset, cardHeight: cardHeight, cardWidth: cardWidth)
         }
       }
-      .padding(.top, cardTopPadding)
-      .padding(.bottom, cardBottomPadding)
-      .frame(maxHeight: .infinity, alignment: .top)  // header 상단 고정
+      .padding(.top, cardTopPadding(cardHeight: cardHeight))
+      .padding(.bottom, cardBottomPadding(cardHeight: cardHeight))
+      .frame(width: cardWidth, height: cardHeight, alignment: .top)
 
       if !viewModel.shouldShowLineup {
         hasNoGameView(asset: asset)
@@ -137,10 +151,17 @@ extension LineupView {
     }
   }
 
-  private func teamName(asset: LineupAssetVO, gameInfo: LineupGameInfoVO) -> some View {
+  private func teamName(
+    asset: LineupAssetVO,
+    gameInfo: LineupGameInfoVO,
+    cardHeight: CGFloat
+  ) -> some View {
     Text(gameInfo.teamEnglishName)
       .font(.T1)
       .foregroundStyle(.grayWhite)
+      .lineLimit(1)
+      .minimumScaleFactor(0.9)
+      .frame(height: teamNameHeight, alignment: .center)
       .shadow(
         color: asset.cardTextShadowColor,
         radius: 8,
@@ -174,7 +195,11 @@ extension LineupView {
     .foregroundColor(.grayWhite)
   }
 
-  private func lineupList(asset: LineupAssetVO, cardHeight: CGFloat, cardWidth: CGFloat)
+  private func lineupList(
+    asset: LineupAssetVO,
+    cardHeight: CGFloat,
+    cardWidth: CGFloat
+  )
     -> some View
   {
     List {
@@ -182,7 +207,8 @@ extension LineupView {
         VStack(spacing: 0) {
           LineupMemberCell(
             player: player,
-            asset: asset
+            asset: asset,
+            isCompact: isCompact(cardHeight: cardHeight)
           )
           .frame(height: cellHeight(cardHeight: cardHeight))
           .padding(.horizontal, 5.5)
@@ -248,6 +274,8 @@ extension LineupView {
     .listStyle(.plain)
     .scrollDisabled(true)
     .scrollContentBackground(.hidden)
+    .contentMargins(.vertical, 0, for: .scrollContent)
+    .environment(\.defaultMinListRowHeight, 0)
     .clipShape(Rectangle())
   }
 

--- a/CheerLot/WidgetCheerLot/Domain/UseCaseImpl/WidgetSyncUseCaseImpl.swift
+++ b/CheerLot/WidgetCheerLot/Domain/UseCaseImpl/WidgetSyncUseCaseImpl.swift
@@ -50,7 +50,8 @@ final class WidgetSyncUseCaseImpl: WidgetSyncUseCase {
       throw LocalStorageError.notFound
     }
 
-    let resolvedStatus = resolvedGameStatus(updatedTeam.gameInfo.status, hasGame: schedule.recentGames.first?.hasGame)
+    let resolvedStatus = resolvedGameStatus(
+      updatedTeam.gameInfo.status, hasGame: schedule.recentGames.first?.hasGame)
     return WidgetGamesInfo(
       schedule: schedule,
       gameStatus: resolvedStatus
@@ -63,7 +64,8 @@ final class WidgetSyncUseCaseImpl: WidgetSyncUseCase {
       let localTeam = try? await teamLocalRepository.fetchTeam(teamId)
     else { return nil }
 
-    let resolvedStatus = resolvedGameStatus(localTeam.gameInfo.status, hasGame: schedule.recentGames.first?.hasGame)
+    let resolvedStatus = resolvedGameStatus(
+      localTeam.gameInfo.status, hasGame: schedule.recentGames.first?.hasGame)
     return WidgetGamesInfo(
       schedule: schedule,
       gameStatus: resolvedStatus

--- a/CheerLot/WidgetCheerLot/Domain/UseCaseImpl/WidgetSyncUseCaseImpl.swift
+++ b/CheerLot/WidgetCheerLot/Domain/UseCaseImpl/WidgetSyncUseCaseImpl.swift
@@ -50,9 +50,10 @@ final class WidgetSyncUseCaseImpl: WidgetSyncUseCase {
       throw LocalStorageError.notFound
     }
 
+    let resolvedStatus = resolvedGameStatus(updatedTeam.gameInfo.status, hasGame: schedule.recentGames.first?.hasGame)
     return WidgetGamesInfo(
       schedule: schedule,
-      gameStatus: updatedTeam.gameInfo.status
+      gameStatus: resolvedStatus
     )
   }
 
@@ -62,9 +63,10 @@ final class WidgetSyncUseCaseImpl: WidgetSyncUseCase {
       let localTeam = try? await teamLocalRepository.fetchTeam(teamId)
     else { return nil }
 
+    let resolvedStatus = resolvedGameStatus(localTeam.gameInfo.status, hasGame: schedule.recentGames.first?.hasGame)
     return WidgetGamesInfo(
       schedule: schedule,
-      gameStatus: localTeam.gameInfo.status
+      gameStatus: resolvedStatus
     )
   }
 }
@@ -72,6 +74,14 @@ final class WidgetSyncUseCaseImpl: WidgetSyncUseCase {
 // MARK: - Private
 
 extension WidgetSyncUseCaseImpl {
+  private func resolvedGameStatus(_ status: GameStatus, hasGame: Bool?) -> GameStatus {
+    guard hasGame == false else { return status }
+    switch status {
+    case .playingToday, .lineupPending: return .offDay
+    case .offDay, .seasonEnded: return status
+    }
+  }
+
   private func syncGameInfo(_ teamId: TeamID, localTeam: TeamState) async throws {
     let gameInfo = try await teamRemoteRepository.fetchTodayGameInfo(teamId)
 

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Common/Component/CapsuleBaseView.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Common/Component/CapsuleBaseView.swift
@@ -6,10 +6,13 @@
 //
 
 import SwiftUI
+import WidgetKit
 
 struct CapsuleBaseView: View {
   let title: String
   let bgColor: Color
+    
+  @Environment(\.widgetRenderingMode) var renderingMode
 
   var body: some View {
     HStack(spacing: 1) {
@@ -19,10 +22,14 @@ struct CapsuleBaseView: View {
       Image(systemName: "baseball.diamond.bases")
         .font(.system(size: 9, weight: .regular))
     }
+    .widgetAccentable()
     .foregroundStyle(.grayWhite)
     .padding(.horizontal, 9)
     .padding(.vertical, 5)
-    .background(Capsule().fill(bgColor))
+    .background(
+        Capsule()
+            .fill(renderingMode == .accented ? .white.opacity(0.25) : bgColor)
+    )
   }
 }
 

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Common/Component/CapsuleBaseView.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Common/Component/CapsuleBaseView.swift
@@ -11,7 +11,7 @@ import WidgetKit
 struct CapsuleBaseView: View {
   let title: String
   let bgColor: Color
-    
+
   @Environment(\.widgetRenderingMode) var renderingMode
 
   var body: some View {
@@ -27,8 +27,8 @@ struct CapsuleBaseView: View {
     .padding(.horizontal, 9)
     .padding(.vertical, 5)
     .background(
-        Capsule()
-            .fill(renderingMode == .accented ? .white.opacity(0.25) : bgColor)
+      Capsule()
+        .fill(renderingMode == .accented ? .white.opacity(0.25) : bgColor)
     )
   }
 }

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Common/Component/GameScheduleCell.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Common/Component/GameScheduleCell.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import WidgetKit
 
 struct GameScheduleCell: View {
   let team: String
@@ -22,14 +23,13 @@ struct GameScheduleCell: View {
       Text(game.date.slashDateFormatted)
         .font(.M6)
         .foregroundStyle(asset.primaryPalette.color200)
+        .widgetAccentable()
     }
     .padding(.horizontal, 10)
     .padding(.vertical, 11)
     .background(
       RoundedRectangle(cornerRadius: 11)
-        .fill(
-          isToday ? .white.opacity(0.25) : .white.opacity(0.1)
-        )
+        .fill(isToday ? Color.white.opacity(0.25) : Color.white.opacity(0.1))
     )
   }
 }
@@ -47,10 +47,12 @@ extension GameScheduleCell {
             .font(.T4)
         }
         .foregroundStyle(.grayWhite)
+        .widgetAccentable()
       } else {
         Text("경기 없음")
           .font(.M5)
           .foregroundStyle(asset.primaryPalette.color200)
+          .widgetAccentable()
       }
     }
   }

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Common/View/GameInfoView.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Common/View/GameInfoView.swift
@@ -18,10 +18,10 @@ struct GameInfoView: View {
 
   var body: some View {
     ZStack(alignment: .topTrailing) {
-        if renderingMode != .accented {
-            asset.primaryColor
-            asset.widgetBackgroundGradient.opacity(0.2)
-        }
+      if renderingMode != .accented {
+        asset.primaryColor
+        asset.widgetBackgroundGradient.opacity(0.2)
+      }
 
       contentsView
 

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Common/View/GameInfoView.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Common/View/GameInfoView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import WidgetKit
 
 struct GameInfoView: View {
   let isSmallSize: Bool
@@ -13,18 +14,18 @@ struct GameInfoView: View {
   let dateString: String
   let capsuleTitle: String
   let asset: WidgetTeamAssetVO
+  @Environment(\.widgetRenderingMode) var renderingMode
 
   var body: some View {
     ZStack(alignment: .topTrailing) {
-      ZStack {
-        asset.primaryColor
+        if renderingMode != .accented {
+            asset.widgetBackgroundGradient.opacity(0.2)
+        }
 
-        asset.widgetBackgroundGradient.opacity(0.2)
-
-        contentsView
-      }
+      contentsView
 
       ReloadButton(color: asset.primaryPalette.color200)
+        .widgetAccentable()
         .padding([.top, .trailing], 18)
     }
   }
@@ -36,10 +37,12 @@ extension GameInfoView {
       Text(dateString)
         .font(.M5)
         .foregroundStyle(asset.primaryPalette.color200)
+        .widgetAccentable()
 
       Text(title)
         .font(isSmallSize ? .SB5 : .SB3)
         .foregroundStyle(.grayWhite)
+        .widgetAccentable()
     }
   }
 
@@ -55,6 +58,7 @@ extension GameInfoView {
       )
       Spacer()
     }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 }
 

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Common/View/GameInfoView.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Common/View/GameInfoView.swift
@@ -19,6 +19,7 @@ struct GameInfoView: View {
   var body: some View {
     ZStack(alignment: .topTrailing) {
         if renderingMode != .accented {
+            asset.primaryColor
             asset.widgetBackgroundGradient.opacity(0.2)
         }
 

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Common/View/TeamEmptyView.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Common/View/TeamEmptyView.swift
@@ -6,23 +6,25 @@
 //
 
 import SwiftUI
+import WidgetKit
 
 struct TeamEmptyView: View {
   let isSmallSize: Bool
+  @Environment(\.widgetRenderingMode) var renderingMode
 
   var body: some View {
     ZStack {
-      Color.white
-
-      LinearGradient(
-        colors: [
-          .grayWhite,
-          .appPrimary,
-        ],
-        startPoint: .top,
-        endPoint: .bottom
-      )
-      .opacity(0.2)
+        if renderingMode != .accented {
+            LinearGradient(
+                colors: [
+                    .grayWhite,
+                    .appPrimary,
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .opacity(0.2)
+        }
 
       contentsView
     }
@@ -35,11 +37,13 @@ extension TeamEmptyView {
       Text("팀 정보 없음")
         .font(isSmallSize ? .SB5 : .SB3)
         .foregroundStyle(Color.appPrimary)
+        .widgetAccentable()
 
       if !isSmallSize {
         Text("앱에서 팀을 선택해주세요")
           .font(.M5)
           .foregroundStyle(.gray400)
+          .widgetAccentable()
       }
     }
   }

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Common/View/TeamEmptyView.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Common/View/TeamEmptyView.swift
@@ -14,17 +14,17 @@ struct TeamEmptyView: View {
 
   var body: some View {
     ZStack {
-        if renderingMode != .accented {
-            LinearGradient(
-                colors: [
-                    .grayWhite,
-                    .appPrimary,
-                ],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-            .opacity(0.2)
-        }
+      if renderingMode != .accented {
+        LinearGradient(
+          colors: [
+            .grayWhite,
+            .appPrimary,
+          ],
+          startPoint: .top,
+          endPoint: .bottom
+        )
+        .opacity(0.2)
+      }
 
       contentsView
     }

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeGameInfo/HomeGameInfoMediumWidget.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeGameInfo/HomeGameInfoMediumWidget.swift
@@ -14,7 +14,13 @@ struct HomeGameInfoMediumWidget: Widget {
   var body: some WidgetConfiguration {
     StaticConfiguration(kind: kind, provider: TeamGamesProvider()) { entry in
       HomeGameInfoMediumWidgetView(entry: entry)
-        .containerBackground(.clear, for: .widget)
+        .containerBackground(for: .widget) {
+          if entry.teamId.isEmpty {
+            Color.white
+          } else {
+            WidgetTeamAssetVO(TeamID(entry.teamId)).primaryColor
+          }
+        }
         .widgetURL(URL(string: "cheerlot://lineup?from=\(WidgetKind.homeGameInfoMedium)"))
     }
     .configurationDisplayName("오늘 경기")

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeGameInfo/HomeGameInfoSmallWidget.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeGameInfo/HomeGameInfoSmallWidget.swift
@@ -14,7 +14,13 @@ struct HomeGameInfoSmallWidget: Widget {
   var body: some WidgetConfiguration {
     StaticConfiguration(kind: kind, provider: TeamGamesProvider()) { entry in
       HomeGameInfoSmallWidgetView(entry: entry)
-        .containerBackground(.clear, for: .widget)
+        .containerBackground(for: .widget) {
+          if entry.teamId.isEmpty {
+            Color.white
+          } else {
+            WidgetTeamAssetVO(TeamID(entry.teamId)).primaryColor
+          }
+        }
         .widgetURL(URL(string: "cheerlot://lineup?from=\(WidgetKind.homeGameInfoSmall)"))
     }
     .configurationDisplayName("오늘 경기")

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeGameInfo/View/HomeGameInfoMediumWidgetView.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeGameInfo/View/HomeGameInfoMediumWidgetView.swift
@@ -11,7 +11,7 @@ import WidgetKit
 struct HomeGameInfoMediumWidgetView: View {
   let entry: TeamGamesEntry
   @Environment(\.widgetRenderingMode) var renderingMode
-    
+
   private var teamAsset: WidgetTeamAssetVO {
     WidgetTeamAssetVO(TeamID(entry.teamId))
   }

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeGameInfo/View/HomeGameInfoMediumWidgetView.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeGameInfo/View/HomeGameInfoMediumWidgetView.swift
@@ -6,10 +6,12 @@
 //
 
 import SwiftUI
+import WidgetKit
 
 struct HomeGameInfoMediumWidgetView: View {
   let entry: TeamGamesEntry
-
+  @Environment(\.widgetRenderingMode) var renderingMode
+    
   private var teamAsset: WidgetTeamAssetVO {
     WidgetTeamAssetVO(TeamID(entry.teamId))
   }
@@ -40,15 +42,14 @@ struct HomeGameInfoMediumWidgetView: View {
 extension HomeGameInfoMediumWidgetView {
   private var playingTodayView: some View {
     ZStack(alignment: .topTrailing) {
-      ZStack {
-        teamAsset.primaryColor
-
+      if renderingMode != .accented {
         teamAsset.widgetBackgroundGradient.opacity(0.2)
-
-        contentsView
       }
 
+      contentsView
+
       ReloadButton(color: teamAsset.primaryPalette.color200)
+        .widgetAccentable()
         .padding([.top, .trailing], 18)
     }
   }
@@ -62,6 +63,7 @@ extension HomeGameInfoMediumWidgetView {
         bgColor: teamAsset.primaryPalette.color500
       )
     }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 
   private var gameInfoContentsView: some View {
@@ -104,10 +106,12 @@ extension HomeGameInfoMediumWidgetView {
       Text(entry.date.koreanDateFormatted)
         .font(.M5)
         .foregroundStyle(teamAsset.primaryPalette.color200)
+        .widgetAccentable()
 
       Text("vs")
         .font(.B1)
         .foregroundStyle(.grayWhite)
+        .widgetAccentable()
     }
   }
 
@@ -115,25 +119,29 @@ extension HomeGameInfoMediumWidgetView {
     VStack(spacing: 0) {
       asset.noCoverImage
         .resizable()
+        .widgetAccentedRenderingMode(.fullColor)
         .scaledToFit()
         .frame(width: 56)
-        .shadow(color: .white.opacity(0.1), radius: 20, x: 0, y: 0)
+        .shadow(color: Color.white.opacity(0.1), radius: 20, x: 0, y: 0)
 
       Text(team)
         .font(.SB8)
         .foregroundStyle(.grayWhite)
         .fixedSize()
+        .widgetAccentable()
 
       if let pitcher {
         HStack(spacing: 2) {
           Image(.pitcher)
             .resizable()
+            .widgetAccentedRenderingMode(.accentedDesaturated)
             .scaledToFit()
             .frame(width: 10)
 
           Text(pitcher)
             .font(.M6)
             .fixedSize()
+            .widgetAccentable()
         }
         .foregroundStyle(teamAsset.primaryPalette.color200)
       }

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeGameInfo/View/HomeGameInfoMediumWidgetView.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeGameInfo/View/HomeGameInfoMediumWidgetView.swift
@@ -43,6 +43,7 @@ extension HomeGameInfoMediumWidgetView {
   private var playingTodayView: some View {
     ZStack(alignment: .topTrailing) {
       if renderingMode != .accented {
+        teamAsset.primaryColor
         teamAsset.widgetBackgroundGradient.opacity(0.2)
       }
 

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomePlayback/HomePlaybackWidget.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomePlayback/HomePlaybackWidget.swift
@@ -81,7 +81,13 @@ struct HomePlaybackWidget: Widget {
   var body: some WidgetConfiguration {
     StaticConfiguration(kind: kind, provider: HomePlaybackProvider()) { entry in
       HomePlaybackWidgetView(entry: entry)
-        .containerBackground(Color.clear, for: .widget)
+        .containerBackground(for: .widget) {
+          if entry.teamId.isEmpty {
+            Color.white
+          } else {
+            WidgetTeamAssetVO(TeamID(entry.teamId)).primaryColor
+          }
+        }
     }
     .configurationDisplayName("응원가 플레이어")
     .description("응원가를 홈화면에서 바로 재생해요.")

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomePlayback/View/HomePlaybackWidgetView.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomePlayback/View/HomePlaybackWidgetView.swift
@@ -57,6 +57,7 @@ extension HomePlaybackWidgetView {
   private var PlaybackStateView: some View {
     ZStack {
         if renderingMode != .accented {
+            asset.primaryColor
             asset.widgetBackgroundGradient.opacity(0.2)
         }
       contentsView

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomePlayback/View/HomePlaybackWidgetView.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomePlayback/View/HomePlaybackWidgetView.swift
@@ -13,6 +13,8 @@ import WidgetKit
 struct HomePlaybackWidgetView: View {
   let entry: HomePlaybackEntry
 
+  @Environment(\.widgetRenderingMode) var renderingMode
+
   private var asset: WidgetTeamAssetVO {
     WidgetTeamAssetVO(TeamID(entry.teamId))
   }
@@ -54,8 +56,9 @@ struct HomePlaybackWidgetView: View {
 extension HomePlaybackWidgetView {
   private var PlaybackStateView: some View {
     ZStack {
-      asset.primaryColor
-      asset.widgetBackgroundGradient.opacity(0.2)
+        if renderingMode != .accented {
+            asset.widgetBackgroundGradient.opacity(0.2)
+        }
       contentsView
     }
   }
@@ -64,6 +67,7 @@ extension HomePlaybackWidgetView {
     VStack(alignment: .leading, spacing: 10) {
       asset.coverImage
         .resizable()
+        .widgetAccentedRenderingMode(.fullColor)
         .scaledToFit()
         .frame(width: 84, height: 84)
         .clipShape(RoundedRectangle(cornerRadius: 12))
@@ -88,22 +92,25 @@ extension HomePlaybackWidgetView {
         .font(.SB8)
         .foregroundStyle(.grayWhite)
         .lineLimit(1)
+        .widgetAccentable()
 
       Text(subtitle)
         .font(.M5)
         .foregroundStyle(asset.primaryPalette.color200)
         .lineLimit(1)
+        .widgetAccentable()
     }
   }
 
   private var playImage: some View {
     Circle()
-      .fill(asset.primaryPalette.color500)
+      .fill(renderingMode == .accented ? .white.opacity(0.25) : asset.primaryPalette.color500)
       .frame(width: 32, height: 32)
       .overlay {
         Image(systemName: "play.fill")
           .font(.system(size: 14, weight: .regular))
           .foregroundStyle(.grayWhite)
+          .widgetAccentable()
       }
   }
 }

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomePlayback/View/HomePlaybackWidgetView.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomePlayback/View/HomePlaybackWidgetView.swift
@@ -56,10 +56,10 @@ struct HomePlaybackWidgetView: View {
 extension HomePlaybackWidgetView {
   private var PlaybackStateView: some View {
     ZStack {
-        if renderingMode != .accented {
-            asset.primaryColor
-            asset.widgetBackgroundGradient.opacity(0.2)
-        }
+      if renderingMode != .accented {
+        asset.primaryColor
+        asset.widgetBackgroundGradient.opacity(0.2)
+      }
       contentsView
     }
   }

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeSchedule/HomeGameScheduleMediumWidget.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeSchedule/HomeGameScheduleMediumWidget.swift
@@ -14,7 +14,13 @@ struct HomeGameScheduleMediumWidget: Widget {
   var body: some WidgetConfiguration {
     StaticConfiguration(kind: kind, provider: TeamGamesProvider()) { entry in
       HomeGameScheduleMediumWidgetView(entry: entry)
-        .containerBackground(.clear, for: .widget)
+        .containerBackground(for: .widget) {
+          if entry.teamId.isEmpty {
+            Color.white
+          } else {
+            WidgetTeamAssetVO(TeamID(entry.teamId)).primaryColor
+          }
+        }
         .widgetURL(URL(string: "cheerlot://lineup?from=\(WidgetKind.homeGameScheduleMedium)"))
     }
     .configurationDisplayName("전체 일정")

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeSchedule/View/HomeGameScheduleMediumWidgetView.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeSchedule/View/HomeGameScheduleMediumWidgetView.swift
@@ -6,9 +6,11 @@
 //
 
 import SwiftUI
+import WidgetKit
 
 struct HomeGameScheduleMediumWidgetView: View {
   let entry: TeamGamesEntry
+  @Environment(\.widgetRenderingMode) var renderingMode
 
   private var asset: WidgetTeamAssetVO {
     WidgetTeamAssetVO(TeamID(entry.teamId))
@@ -31,10 +33,9 @@ struct HomeGameScheduleMediumWidgetView: View {
 extension HomeGameScheduleMediumWidgetView {
   private var notSeasonOutView: some View {
     ZStack {
-      asset.primaryColor
-
-      asset.widgetBackgroundGradient.opacity(0.2)
-
+        if renderingMode != .accented {
+            asset.widgetBackgroundGradient.opacity(0.2)
+        }
       notSeasonOutContentsView
     }
   }
@@ -44,10 +45,12 @@ extension HomeGameScheduleMediumWidgetView {
       Text(entry.date.dayOfWeek)
         .font(.M5)
         .foregroundStyle(.gray100)
+        .widgetAccentable()
 
       Text(entry.date.dayOfMonth)
         .font(.B3)
         .foregroundStyle(.grayWhite)
+        .widgetAccentable()
     }
   }
 
@@ -57,17 +60,17 @@ extension HomeGameScheduleMediumWidgetView {
 
       asset.noCoverImage
         .resizable()
+        .widgetAccentedRenderingMode(.fullColor)
         .scaledToFit()
         .frame(width: 60)
-        .shadow(color: .white.opacity(0.15), radius: 20, x: 0, y: 0)
+        .shadow(color: Color.white.opacity(0.15), radius: 20, x: 0, y: 0)
     }
     .frame(width: 60)
   }
 
   private var gameScheduleView: some View {
     LazyVStack(spacing: 6) {
-      ForEach(Array(entry.gameSchedule.enumerated()), id: \.offset) {
-        index, game in
+      ForEach(Array(entry.gameSchedule.enumerated()), id: \.offset) { index, game in
         GameScheduleCell(team: entry.teamId, game: game, asset: asset, isToday: index == 0)
           .frame(maxWidth: .infinity)
       }

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeSchedule/View/HomeGameScheduleMediumWidgetView.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeSchedule/View/HomeGameScheduleMediumWidgetView.swift
@@ -34,6 +34,7 @@ extension HomeGameScheduleMediumWidgetView {
   private var notSeasonOutView: some View {
     ZStack {
         if renderingMode != .accented {
+            asset.primaryColor
             asset.widgetBackgroundGradient.opacity(0.2)
         }
       notSeasonOutContentsView

--- a/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeSchedule/View/HomeGameScheduleMediumWidgetView.swift
+++ b/CheerLot/WidgetCheerLot/Presentation/HomeScreen/Widget/HomeSchedule/View/HomeGameScheduleMediumWidgetView.swift
@@ -33,10 +33,10 @@ struct HomeGameScheduleMediumWidgetView: View {
 extension HomeGameScheduleMediumWidgetView {
   private var notSeasonOutView: some View {
     ZStack {
-        if renderingMode != .accented {
-            asset.primaryColor
-            asset.widgetBackgroundGradient.opacity(0.2)
-        }
+      if renderingMode != .accented {
+        asset.primaryColor
+        asset.widgetBackgroundGradient.opacity(0.2)
+      }
       notSeasonOutContentsView
     }
   }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #87
---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 위젯 hasGame 데이터도 status에 같이 반영
   - 기존에는 swiftdata의 hasTodayGame과 isSeasonEnded 조합으로 TeamGameInfo Entity 추출하여 status를 판단하였지만, 서버 경기 정보 동기화 시간에 발생하는 오류를 줄이기 위해 경기스케줄 속 경기의 hasGame 속성까지 고려해서 status 판단
- 위젯 tinted 대응
   - 기존 기본/다크 모드 제외시 흰 화면으로만 뜨는 위젯 버그를 수정함
   - .widgetAccentable() / @Environment(\.widgetRenderingMode) var renderingMode 사용하여 tinted 주는 컴포넌트에 적용
   - .containerBackground(for: .widget)를 clear에서 각 위젯의 배경으로 대체
- SE 3세대 iOS 26이상, iPad, macOS에서의 LineupView 화면 깨짐 수정
   - isCompact 적용 및 list cell contents 및 lineupCard 내의 spacing, padding 값 분기 처리
   - list에 .contentMargins(.vertical, 0, for: .scrollContent), .environment(\.defaultMinListRowHeight, 0) 수정자 적용
   - cardContents에서 .frame(maxHeight: .infinity, alignment: .top)  // header 상단 고정에서 .frame(width: cardWidth, height: cardHeight, alignment: .top)로 대체
---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/6fd5eff5-c6ff-4cd3-84d5-14d62a177c63" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 17, iOS 26 환경에서 정상 동작
- [x] 포매터 수행

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 기존 fix 예정이었던 task인 앱 내에서 refresh시, (당겨서) 강제 업데이트로 변경는 보류했습니다
   - 강제 refresh 적용시, 사용자가 교체했던 선수도 강제 update로 인해 사라지기 때문
   - 교체 선수 사용률이 낮으면 force 업데이트 도입을 고려해볼만 하지만 관련 논의 없이 서버 업데이트 시간과 맞물려 사용시 발생할 수 있는 오류 때문만으로 적용하는건 무리라고 생각했습니다.

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- 위젯 tinted 처리
- LineupView 기기 대응


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 라인업 카드의 컴팩트 레이아웃 지원으로 더 나은 공간 활용
  * 위젯 배경이 팀 색상으로 동적 표시됨
  * 위젯 강조 모드(accent mode) 지원으로 향상된 커스터마이제이션

* **개선사항**
  * 라인업 뷰의 반응형 레이아웃 개선
  * 위젯 렌더링 품질 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->